### PR TITLE
Add JSON serialization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ gem "jbuilder"
 # Tailwind CSS, a utility-first CSS framework [https://tailwindcss.com/]
 gem "tailwindcss-ruby", "~> 4.1"
 gem "tailwindcss-rails", "~> 4.2"
+# Use Blueprinter as a JSON serializer
+gem "blueprinter"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     bindex (0.8.1)
+    blueprinter (1.1.2)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     brakeman (7.0.2)
@@ -392,6 +393,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  blueprinter
   bootsnap
   brakeman
   cssbundling-rails

--- a/app/blueprints/menu_blueprint.rb
+++ b/app/blueprints/menu_blueprint.rb
@@ -1,0 +1,11 @@
+class MenuBlueprint < Blueprinter::Base
+  identifier :id
+
+  field :name
+
+  field :menu_items do |menu, options|
+    menu.menu_entries.includes(:menu_item).map do |entry|
+      MenuItemBlueprint.render_as_hash(entry.menu_item, menu_entry: entry)
+    end
+  end
+end

--- a/app/blueprints/menu_item_blueprint.rb
+++ b/app/blueprints/menu_item_blueprint.rb
@@ -1,0 +1,30 @@
+class MenuItemBlueprint < Blueprinter::Base
+  identifier :id
+
+  field :name
+
+  field :price do |menu_item, options|
+    entry = options[:menu_entry] || options.dig(:menu_entries, menu_item.id)
+    entry&.price&.to_s
+  end
+
+    field :description do |menu_item, options|
+      entry = options[:menu_entry] || options.dig(:menu_entries, menu_item.id)
+      entry&.description
+    end
+
+  field :category do |menu_item, options|
+    entry = options[:menu_entry] || options.dig(:menu_entries, menu_item.id)
+    entry&.category
+  end
+
+  field :dietary_restrictions do |menu_item, options|
+    entry = options[:menu_entry] || options.dig(:menu_entries, menu_item.id)
+    entry&.dietary_restrictions
+  end
+
+  field :ingredients do |menu_item, options|
+    entry = options[:menu_entry] || options.dig(:menu_entries, menu_item.id)
+    entry&.ingredients
+  end
+end

--- a/app/blueprints/restaurant_blueprint.rb
+++ b/app/blueprints/restaurant_blueprint.rb
@@ -1,0 +1,7 @@
+class RestaurantBlueprint < Blueprinter::Base
+  identifier :id
+
+  field :name
+
+  association :menus, blueprint: MenuBlueprint
+end

--- a/app/controllers/api/v1/menu_items_controller.rb
+++ b/app/controllers/api/v1/menu_items_controller.rb
@@ -5,13 +5,18 @@ class Api::V1::MenuItemsController < ApplicationController
   # GET /menu_items.json
   def index
     @menu_items = MenuItem.all
-    render json: @menu_items
+    menu_entries = MenuEntry.where(
+      menu_item_id: @menu_items.map(&:id),
+      menu_id: params[:menu_id]
+    ).index_by(&:menu_item_id)
+
+    render json: MenuItemBlueprint.render(@menu_items, menu_entries:)
   end
 
   # GET /menu_items/1
   # GET /menu_items/1.json
   def show
-    render json: @menu_item
+    render json: MenuItemBlueprint.render(@menu_item)
   end
 
   # POST /menu_items
@@ -28,7 +33,7 @@ class Api::V1::MenuItemsController < ApplicationController
       )
 
       if @menu_entry.save
-        render json: { menu_item: @menu_item, menu_entry: @menu_entry }, status: :created
+        render json: MenuItemBlueprint.render(@menu_item, menu_entry: @menu_entry), status: :created
       else
         render json: { errors: @menu_entry.errors }, status: :unprocessable_entity
       end
@@ -48,7 +53,7 @@ class Api::V1::MenuItemsController < ApplicationController
 
       if @menu_entry
         if @menu_entry.update(menu_item_params.except(:name))
-          render json: { menu_item: @menu_item, menu_entry: @menu_entry }, status: :ok
+          render json: MenuItemBlueprint.render(@menu_item, menu_entry: @menu_entry), status: :ok
         else
           render json: { errors: @menu_entry.errors }, status: :unprocessable_entity
         end

--- a/app/controllers/api/v1/menu_items_controller.rb
+++ b/app/controllers/api/v1/menu_items_controller.rb
@@ -61,14 +61,10 @@ class Api::V1::MenuItemsController < ApplicationController
           menu_id: menu_item_params[:menu_id]
         )
 
-        if @menu_entry
-          if @menu_entry.update(menu_item_params.except(:name))
-            render json: MenuItemBlueprint.render(@menu_item, menu_entry: @menu_entry), status: :ok
-          else
-            render json: { errors: @menu_entry.errors }, status: :unprocessable_entity
-          end
+        if @menu_entry.update(menu_item_params.except(:name))
+          render json: MenuItemBlueprint.render(@menu_item, menu_entry: @menu_entry), status: :ok
         else
-          render json: { errors: "Menu entry not found" }, status: :not_found
+          render json: { errors: @menu_entry.errors }, status: :unprocessable_entity
         end
       else
         render json: { errors: @menu_item.errors }, status: :unprocessable_entity
@@ -85,7 +81,7 @@ class Api::V1::MenuItemsController < ApplicationController
       if @menu_item.destroy
         render json: { message: "Item deleted successfully" }, status: :ok
       else
-        render json: { errors: @menu.errors }, status: :unprocessable_entity
+        render json: { errors: @menu_item.errors }, status: :unprocessable_entity
       end
     else
       render json: { errors: "Menu item not found" }, status: :not_found

--- a/app/controllers/api/v1/menu_items_controller.rb
+++ b/app/controllers/api/v1/menu_items_controller.rb
@@ -16,7 +16,16 @@ class Api::V1::MenuItemsController < ApplicationController
   # GET /menu_items/1
   # GET /menu_items/1.json
   def show
-    render json: MenuItemBlueprint.render(@menu_item)
+    if @menu_item
+      render json: MenuItemBlueprint.render(
+        @menu_item,
+        menu_entries: @menu_item.menu_entries
+          .where(menu_id: params[:menu_id])
+          .index_by(&:menu_item_id)
+      )
+    else
+      render json: { errors: "Menu item not found" }, status: :not_found
+    end
   end
 
   # POST /menu_items
@@ -45,40 +54,48 @@ class Api::V1::MenuItemsController < ApplicationController
   # PATCH/PUT /menu_items/1
   # PATCH/PUT /menu_items/1.json
   def update
-    if @menu_item.update(name: menu_item_params[:name])
-      @menu_entry = MenuEntry.find_or_create_by(
-        menu_item_id: @menu_item.id,
-        menu_id: menu_item_params[:menu_id]
-      )
+    if @menu_item
+      if @menu_item.update(name: menu_item_params[:name])
+        @menu_entry = MenuEntry.find_or_create_by(
+          menu_item_id: @menu_item.id,
+          menu_id: menu_item_params[:menu_id]
+        )
 
-      if @menu_entry
-        if @menu_entry.update(menu_item_params.except(:name))
-          render json: MenuItemBlueprint.render(@menu_item, menu_entry: @menu_entry), status: :ok
+        if @menu_entry
+          if @menu_entry.update(menu_item_params.except(:name))
+            render json: MenuItemBlueprint.render(@menu_item, menu_entry: @menu_entry), status: :ok
+          else
+            render json: { errors: @menu_entry.errors }, status: :unprocessable_entity
+          end
         else
-          render json: { errors: @menu_entry.errors }, status: :unprocessable_entity
+          render json: { errors: "Menu entry not found" }, status: :not_found
         end
       else
-        render json: { errors: "Menu entry not found" }, status: :not_found
+        render json: { errors: @menu_item.errors }, status: :unprocessable_entity
       end
     else
-      render json: { errors: @menu_item.errors }, status: :unprocessable_entity
+      render json: { errors: "Menu item not found" }, status: :not_found
     end
   end
 
   # DELETE /menu_items/1
   # DELETE /menu_items/1.json
   def destroy
-    if @menu_item.destroy
-      render json: { message: "Item deleted successfully" }, status: :ok
+    if @menu_item
+      if @menu_item.destroy
+        render json: { message: "Item deleted successfully" }, status: :ok
+      else
+        render json: { errors: @menu.errors }, status: :unprocessable_entity
+      end
     else
-      render json: { errors: @menu.errors }, status: :unprocessable_entity
+      render json: { errors: "Menu item not found" }, status: :not_found
     end
   end
 
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_menu_item
-      @menu_item = MenuItem.find(params.expect(:id))
+      @menu_item = MenuItem.find_by(id: params.expect(:id))
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/api/v1/menus_controller.rb
+++ b/app/controllers/api/v1/menus_controller.rb
@@ -1,20 +1,17 @@
 class Api::V1::MenusController < ApplicationController
   before_action :set_menu, only: %i[ show update destroy ]
+  before_action :set_restaurant
 
   # GET /menus or /menus.json
   def index
-    @menus = Menu.all
-    render json: @menus, include: :menu_items
+    @menus = @restaurant.menus
+    render json: MenuBlueprint.render(@menus)
   end
 
   # GET /menus/1 or /menus/1.json
   def show
-    render json: @menu, include: :menu_items
-  end
-
-  def new
-    @menu = Menu.new
-    render json: @menu
+    @menu = @restaurant.menus.find(params[:id])
+    render json: MenuBlueprint.render(@menu)
   end
 
   # POST /menus or /menus.json
@@ -22,7 +19,7 @@ class Api::V1::MenusController < ApplicationController
     @menu = Menu.new(menu_params)
 
     if @menu.save
-      render json: @menu, include: :menu_items, status: :created
+      render json: MenuBlueprint.render(@menu), status: :created
     else
       render json: { errors: @menu.errors }, status: :unprocessable_entity
     end
@@ -31,7 +28,7 @@ class Api::V1::MenusController < ApplicationController
   # PATCH/PUT /menus/1 or /menus/1.json
   def update
     if @menu.update(menu_params)
-      render json: @menu, include: :menu_items, status: :ok
+      render json: MenuBlueprint.render(@menu), status: :ok
     else
       render json: { errors: @menu.errors }, status: :unprocessable_entity
     end
@@ -50,6 +47,10 @@ class Api::V1::MenusController < ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_menu
       @menu = Menu.find(params.expect(:id))
+    end
+
+    def set_restaurant
+      @restaurant = Restaurant.find(params.expect(:restaurant_id))
     end
 
     # Only allow a list of trusted parameters through.

--- a/app/controllers/api/v1/restaurants_controller.rb
+++ b/app/controllers/api/v1/restaurants_controller.rb
@@ -5,13 +5,13 @@ class Api::V1::RestaurantsController < ApplicationController
   # GET /restaurants.json
   def index
     @restaurants = Restaurant.all
-    render json: @restaurants, include: { menus: { include: :menu_items } }
+    render json: RestaurantBlueprint.render(@restaurants)
   end
 
   # GET /restaurants/1
   # GET /restaurants/1.json
   def show
-    render json: @restaurant, include: { menus: { include: :menu_items } }
+    render json: RestaurantBlueprint.render(@restaurant)
   end
 
   # POST /restaurants
@@ -20,7 +20,7 @@ class Api::V1::RestaurantsController < ApplicationController
     @restaurant = Restaurant.new(restaurant_params)
 
     if @restaurant.save
-      render json: @restaurant, include: { menus: { include: :menu_items } }, status: :created
+      render json: RestaurantBlueprint.render(@restaurant), status: :created
     else
       render json: { errors: @restaurant.errors }, status: :unprocessable_entity
     end
@@ -30,7 +30,7 @@ class Api::V1::RestaurantsController < ApplicationController
   # PATCH/PUT /restaurants/1.json
   def update
     if @restaurant.update(restaurant_params)
-      render json: @restaurant, include: { menus: { include: :menu_items } }, status: :ok
+      render json: RestaurantBlueprint.render(@restaurant), status: :ok
     else
       render json: { errors: @restaurant.errors }, status: :unprocessable_entity
     end

--- a/config/initializers/blueprinter.rb
+++ b/config/initializers/blueprinter.rb
@@ -1,0 +1,3 @@
+Blueprinter.configure do |config|
+  config.sort_fields_by = :definition
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,6 +43,9 @@ end
 RSpec.configure do |config|
   # FactoryBot config for Rails
   config.include FactoryBot::Syntax::Methods
+  config.before do
+    FactoryBot.reload # reset sequences before each test
+  end
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [

--- a/spec/requests/api/v1/menu_items_spec.rb
+++ b/spec/requests/api/v1/menu_items_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "/menu_items", type: :request do
   describe "GET /show" do
     context "when the menu item does not exist" do
       it "returns a not found response (404)" do
-        get api_v1_restaurant_menu_item_url(restaurant, menu, id: -1), as: :json
+        get api_v1_restaurant_menu_item_url(restaurant, menu, id: 999), as: :json
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -193,6 +193,13 @@ RSpec.describe "/menu_items", type: :request do
   end
 
   describe "PATCH /update" do
+    context "when menu item does not exist" do
+      it "returns a 404" do
+        patch api_v1_restaurant_menu_item_url(restaurant, menu, 0)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     context "with valid parameters" do
       let(:new_menu) { create(:menu, restaurant:) }
       let(:new_attributes) {
@@ -317,6 +324,13 @@ RSpec.describe "/menu_items", type: :request do
   end
 
   describe "DELETE /destroy" do
+    context "when the menu item does not exist" do
+      it "returns a 404" do
+        delete api_v1_restaurant_menu_item_url(restaurant, menu, 0)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
     it "destroys the requested menu_item" do
       menu_item = create(:menu_item)
       expect {

--- a/spec/requests/api/v1/menu_items_spec.rb
+++ b/spec/requests/api/v1/menu_items_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "/menu_items", type: :request do
   let(:valid_attributes) {
     {
       menu_id: menu.id,
-      name: "Cheese Burguer",
-      description: "Delicious cheese burguer",
+      name: "Cheese Burger",
+      description: "Delicious cheese burger",
       price: 9.99,
       category: "Main Course",
       dietary_restrictions: "None",
@@ -44,11 +44,17 @@ RSpec.describe "/menu_items", type: :request do
     context "when menu items exist" do
       it "renders a successful response" do
         menu = create(:menu_with_items, menu_items_count: 3, restaurant:)
+        menu_entries = menu.menu_entries
 
         get api_v1_restaurant_menu_items_url(restaurant, menu), headers: valid_headers, as: :json
 
+        parsed_response = JSON.parse(response.body)
+
         expect(response).to be_successful
-        expect(JSON.parse(response.body).size).to eq(3)
+        expect(parsed_response.size).to eq(3)
+        expect(parsed_response.first["name"]).to eq("Menu Item 1")
+        expect(parsed_response.last["name"]).to eq("Menu Item 3")
+        expect(parsed_response.first["price"]).to eq(menu_entries.first.price.to_s)
       end
     end
   end
@@ -116,8 +122,12 @@ RSpec.describe "/menu_items", type: :request do
                params: { menu_item: valid_attributes }, headers: valid_headers, as: :json
           expect(response).to have_http_status(:created)
           expect(response.content_type).to match(a_string_including("application/json"))
-          expect(response.body).to include("menu_item")
-          expect(response.body).to include("menu_entry")
+          expect(response.body).to include('"name":"Cheese Burger"')
+          expect(response.body).to include('"price":"9.99"')
+          expect(response.body).to include('"description":"Delicious cheese burger"')
+          expect(response.body).to include('"category":"Main Course"')
+          expect(response.body).to include('"dietary_restrictions":"None"')
+          expect(response.body).to include('"ingredients":"Beef, Bread, Cheese, Lettuce, Tomato"')
         end
       end
 
@@ -288,7 +298,7 @@ RSpec.describe "/menu_items", type: :request do
 
         expect(another_menu_entry.price).to eq(9.99)
         expect(another_menu_entry.menu_id).to eq(new_menu.id)
-        expect(another_menu_entry.description).to eq("Delicious cheese burguer")
+        expect(another_menu_entry.description).to eq("Delicious cheese burger")
         expect(another_menu_entry.category).to eq("Main Course")
         expect(another_menu_entry.dietary_restrictions).to eq("None")
         expect(another_menu_entry.ingredients).to eq("Beef, Bread, Cheese, Lettuce, Tomato")

--- a/spec/requests/api/v1/menus_spec.rb
+++ b/spec/requests/api/v1/menus_spec.rb
@@ -253,5 +253,20 @@ RSpec.describe "/menus", type: :request do
       # Assert
       expect(Menu.find_by(id: menu.id)).to be_nil
     end
+
+    context "when an error occurs while deleting" do
+      it "returns an unprocessable entity (422) status code" do
+        # Arrange
+        menu = instance_double(Menu, destroy: false)
+        allow(Menu).to receive(:find).and_return(menu)
+        allow(menu).to receive(:errors).and_return("Unprocessable Entity")
+
+        # Act
+        delete api_v1_restaurant_menu_url(restaurant, menu)
+
+        # Assert
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 end

--- a/spec/requests/restaurants_spec.rb
+++ b/spec/requests/restaurants_spec.rb
@@ -88,5 +88,20 @@ RSpec.describe "/restaurants", type: :request do
         delete api_v1_restaurant_url(restaurant), as: :json
       }.to change(Restaurant, :count).by(-1)
     end
+
+    context "when an error occurs while deleting" do
+      it "returns an unprocessable entity (422) status code" do
+        # Arrange
+        restaurant = instance_double(Restaurant, destroy: false)
+        allow(Restaurant).to receive(:find).and_return(restaurant)
+        allow(restaurant).to receive(:errors).and_return("Unprocessable Entity")
+
+        # Act
+        delete api_v1_restaurant_url(restaurant)
+
+        # Assert
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
   end
 end


### PR DESCRIPTION
This pull request introduces JSON serialization capabilities to the `popmenu_project`, enhancing the API's ability to return structured JSON responses for key resources such as Restaurants, Menus, and MenuItems.

---

## 📌 Motivation

Implementing JSON serialization is crucial for:

- **Consistent API Responses**: Ensuring that all API endpoints return data in a standardized JSON format.
- **Frontend Integration**: Facilitating seamless consumption of API data by frontend applications.
- **Maintainability**: Centralizing serialization logic to simplify future modifications and enhancements.

---

## 🔧 Changes

- **Serializers Added**:
  - Introduced serializers for core models to define JSON structure.
- **Controller Updates**:
  - Modified controllers to utilize the new serializers for rendering JSON responses.
- **Test Enhancements**:
  - Updated existing tests and added new ones to cover serialization logic and ensure correct JSON output.

---

## ✅ Checklist

- [x] Implemented serializers for all relevant models.
- [x] Updated controllers to use serializers for JSON responses.
- [x] Added and updated tests to cover serialization logic.
- [x] Ensured all tests pass successfully.
- [x] Reviewed and adhered to code style guidelines.
- [x] Verified API responses using tools like Postman or Insomnia.