### PR TITLE
Feat/restaurant import service

### DIFF
--- a/app/controllers/api/v1/restaurant_imports_controller.rb
+++ b/app/controllers/api/v1/restaurant_imports_controller.rb
@@ -1,0 +1,27 @@
+class Api::V1::RestaurantImportsController < ApplicationController
+  def create
+    # Check if file is provided
+    unless params[:file].present?
+      render json: { success: false, logs: [ { level: "error", message: "No file provided" } ] }, status: :bad_request
+      return
+    end
+
+    # Read the file content
+    begin
+      file_content = params[:file].read
+
+      # Initialize service and import data
+      import_service = RestaurantImportService.new
+      result = import_service.import(file_content)
+
+      # Return the result with appropriate status
+      status = result[:success] ? :ok : :unprocessable_entity
+      render json: result, status: status
+    rescue StandardError => e
+      render json: {
+        success: false,
+        logs: [ { level: "error", message: "File processing error: #{e.message}" } ]
+      }, status: :internal_server_error
+    end
+  end
+end

--- a/app/services/restaurant_import_service.rb
+++ b/app/services/restaurant_import_service.rb
@@ -1,0 +1,148 @@
+class RestaurantImportService
+  attr_reader :logs, :success
+
+  def initialize
+    @logs = []
+    @success = true
+  end
+
+  def import(json_data)
+    begin
+      data = parse_json(json_data)
+
+      if data.nil? || !data.key?("restaurants") || !data["restaurants"].is_a?(Array)
+        log_error("Invalid JSON format: Missing 'restaurants' array")
+        return { success: false, logs: @logs }
+      end
+
+      ActiveRecord::Base.transaction do
+        data["restaurants"].each do |restaurant_data|
+          process_restaurant(restaurant_data)
+        end
+      end
+
+    rescue StandardError => e
+      @success = false
+      log_error("Import failed: #{e.message}")
+    end
+
+    { success: @success, logs: @logs }
+  end
+
+  private
+
+  def parse_json(json_data)
+    JSON.parse(json_data)
+  rescue JSON::ParserError => e
+    @success = false
+    log_error("JSON parsing error: #{e.message}")
+    nil
+  end
+
+  def process_restaurant(restaurant_data)
+    # Validate restaurant data
+    unless restaurant_data.key?("name") && restaurant_data["name"].is_a?(String)
+      log_error("Invalid restaurant data: Missing or invalid 'name'")
+      @success = false
+      return
+    end
+
+    # Find or create restaurant
+    restaurant = Restaurant.find_or_create_by(name: restaurant_data["name"])
+    log_info("Restaurant: #{restaurant.name} (#{restaurant.new_record? ? 'Created' : 'Found'})")
+
+    # Process menus if present
+    if restaurant_data.key?("menus") && restaurant_data["menus"].is_a?(Array)
+      restaurant_data["menus"].each do |menu_data|
+        process_menu(restaurant, menu_data)
+      end
+    else
+      log_warning("No menus found for restaurant: #{restaurant.name}")
+    end
+  end
+
+  def process_menu(restaurant, menu_data)
+    # Validate menu data
+    unless menu_data.key?("name") && menu_data["name"].is_a?(String)
+      log_error("Invalid menu data: Missing or invalid 'name'")
+      @success = false
+      return
+    end
+
+    # Find or create menu
+    menu = restaurant.menus.find_or_create_by(name: menu_data["name"])
+    log_info("Menu: #{menu.name} (#{menu.new_record? ? 'Created' : 'Found'})")
+
+    # Process menu items
+    menu_items = menu_data["menu_items"] || menu_data["dishes"] || []
+
+    if menu_items.empty?
+      log_warning("No menu items found for menu: #{menu.name}")
+      return
+    end
+
+    menu_items.each do |item_data|
+      process_menu_item(menu, item_data)
+    end
+  end
+
+  def process_menu_item(menu, item_data)
+    # Validate menu item data
+    unless item_data.key?("name") && item_data.key?("price")
+      log_error("Invalid menu item data: Missing 'name' or 'price'")
+      @success = false
+      return
+    end
+
+    item_name = item_data["name"].strip
+    item_price = item_data["price"].to_f
+
+    # Find or create menu item (keeping them unique in the database)
+    menu_item = MenuItem.find_or_create_by(name: item_name)
+
+    if menu_item.new_record?
+      log_info("Menu item: #{item_name} (Created)")
+    else
+      log_info("Menu item: #{item_name} (Found existing)")
+    end
+
+    # Create the menu entry (join model) with the specified price
+    begin
+      # Check if the menu entry already exists
+      menu_entry = MenuEntry.find_or_create_by(
+        menu_id: menu.id,
+        menu_item_id: menu_item.id
+      )
+
+      # Update the price if it's different
+      if menu_entry.price != item_price
+        menu_entry.update(price: item_price)
+        log_info("Menu entry: #{item_name} on #{menu.name} menu - price updated to $#{item_price}")
+      else
+        log_info("Menu entry: #{item_name} on #{menu.name} menu - price $#{item_price}")
+      end
+    rescue ActiveRecord::RecordInvalid => e
+      log_error("Failed to create menu entry for '#{item_name}': #{e.message}")
+      @success = false
+    end
+  end
+
+
+  # Logs an informational message with the given content.
+  # The message is stored in the logs with an "info" level.
+  #
+  # @param message [String] the informational message to log
+
+  def log_info(message)
+    @logs << { level: "info", message: message }
+  end
+
+  def log_warning(message)
+    @logs << { level: "warning", message: message }
+  end
+
+  def log_error(message)
+    @logs << { level: "error", message: message }
+    @success = false
+  end
+end

--- a/app/services/restaurant_import_service.rb
+++ b/app/services/restaurant_import_service.rb
@@ -48,8 +48,13 @@ class RestaurantImportService
     end
 
     # Find or create restaurant
-    restaurant = Restaurant.find_or_create_by(name: restaurant_data["name"])
-    log_info("Restaurant: #{restaurant.name} (#{restaurant.new_record? ? 'Created' : 'Found'})")
+    restaurant = Restaurant.find_or_initialize_by(name: restaurant_data["name"])
+
+    if restaurant.new_record? && restaurant.save
+      log_info("Restaurant: #{restaurant.name} (Created)")
+    else
+      log_info("Restaurant: #{restaurant.name} (Found)")
+    end
 
     # Process menus if present
     if restaurant_data.key?("menus") && restaurant_data["menus"].is_a?(Array)
@@ -70,8 +75,13 @@ class RestaurantImportService
     end
 
     # Find or create menu
-    menu = restaurant.menus.find_or_create_by(name: menu_data["name"])
-    log_info("Menu: #{menu.name} (#{menu.new_record? ? 'Created' : 'Found'})")
+    menu = restaurant.menus.find_or_initialize_by(name: menu_data["name"])
+
+    if menu.new_record? && menu.save
+      log_info("Menu: #{menu.name} (Created)")
+    else
+      log_info("Menu: #{menu.name} (Found)")
+    end
 
     # Process menu items
     menu_items = menu_data["menu_items"] || menu_data["dishes"] || []
@@ -98,9 +108,9 @@ class RestaurantImportService
     item_price = item_data["price"].to_f
 
     # Find or create menu item (keeping them unique in the database)
-    menu_item = MenuItem.find_or_create_by(name: item_name)
+    menu_item = MenuItem.find_or_initialize_by(name: item_name)
 
-    if menu_item.new_record?
+    if menu_item.new_record? && menu_item.save
       log_info("Menu item: #{item_name} (Created)")
     else
       log_info("Menu item: #{item_name} (Found existing)")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
           resources :menu_items, as: :items, only: [ :index, :show, :create, :update, :destroy ]
         end
       end
+
+      resources :restaurant_imports, only: [ :create ]
     end
   end
 

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,46 @@
+namespace :import do
+  desc "Import restaurant data from a JSON file"
+  task :restaurants, [ :file_path ] => :environment do |t, args|
+    # Check if file path is provided
+    unless args[:file_path].present?
+      puts "Error: File path is required"
+      puts "Usage: rake import:restaurants[path/to/file.json]"
+      exit(1)
+    end
+
+    # Check if file exists
+    file_path = args[:file_path]
+    unless File.exist?(file_path)
+      puts "Error: File not found at '#{file_path}'"
+      exit(1)
+    end
+
+    # Read the file content
+    begin
+      file_content = File.read(file_path)
+
+      # Initialize service and import data
+      import_service = RestaurantImportService.new
+      result = import_service.import(file_content)
+
+      # Output the results
+      puts "Import #{result[:success] ? 'successful' : 'failed'}"
+      puts "Logs:"
+      result[:logs].each do |log|
+        case log[:level]
+        when "info"
+          puts "  [INFO] #{log[:message]}"
+        when "warning"
+          puts "  [WARNING] #{log[:message]}"
+        when "error"
+          puts "  [ERROR] #{log[:message]}"
+        end
+      end
+
+      exit(result[:success] ? 0 : 1)
+    rescue StandardError => e
+      puts "Error: #{e.message}"
+      exit(1)
+    end
+  end
+end

--- a/spec/controllers/api/v1/restaurant_imports_controller_spec.rb
+++ b/spec/controllers/api/v1/restaurant_imports_controller_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::RestaurantImportsController, type: :controller do
+  describe "POST #create" do
+    context "with valid file" do
+      let(:valid_json) do
+        {
+          restaurants: [
+            {
+              name: "Test Restaurant",
+              menus: [
+                {
+                  name: "lunch",
+                  menu_items: [
+                    { name: "Burger", price: 9.0 },
+                    { name: "Salad", price: 5.0 }
+                  ]
+                }
+              ]
+            }
+          ]
+        }.to_json
+      end
+
+      it "imports the restaurant data and returns success" do
+        # Create a temporary file with the JSON content
+        file = Tempfile.new([ 'restaurant_data', '.json' ])
+        file.write(valid_json)
+        file.rewind
+
+        # Create the uploaded file
+        uploaded_file = fixture_file_upload(file.path, 'application/json')
+
+        expect {
+          post :create, params: { file: uploaded_file }
+        }.to change(Restaurant, :count).by(1)
+          .and change(Menu, :count).by(1)
+          .and change(MenuItem, :count).by(2)
+          .and change(MenuEntry, :count).by(2)
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)['success']).to be true
+
+        file.close
+        file.unlink
+      end
+    end
+
+    context "with no file" do
+      it "returns a bad request error" do
+        post :create
+
+        expect(response).to have_http_status(:bad_request)
+        expect(JSON.parse(response.body)['success']).to be false
+        expect(JSON.parse(response.body)['logs'].first['message']).to include('No file provided')
+      end
+    end
+
+    context "with invalid JSON" do
+      it "returns an unprocessable entity error" do
+        # Create a temporary file with invalid JSON
+        file = Tempfile.new([ 'invalid_data', '.json' ])
+        file.write('{ invalid json }')
+        file.rewind
+
+        # Create the uploaded file
+        uploaded_file = fixture_file_upload(file.path, 'application/json')
+
+        post :create, params: { file: uploaded_file }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(JSON.parse(response.body)['success']).to be false
+
+        file.close
+        file.unlink
+      end
+    end
+  end
+end

--- a/spec/fixtures/restaurants.json
+++ b/spec/fixtures/restaurants.json
@@ -1,0 +1,70 @@
+{
+    "restaurants": [
+      {
+        "name": "Poppo's Cafe",
+        "menus": [
+          {
+            "name": "lunch",
+            "menu_items": [
+              {
+                "name": "Burger",
+                "price": 9.00
+              },
+              {
+                "name": "Small Salad",
+                "price": 5.00
+              }
+            ]
+          },
+          {
+            "name": "dinner",
+            "menu_items": [
+              {
+                "name": "Burger",
+                "price": 15.00
+              },
+              {
+                "name": "Large Salad",
+                "price": 8.00
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Casa del Poppo",
+        "menus": [
+          {
+            "name": "lunch",
+            "dishes": [
+              {
+                "name": "Chicken Wings",
+                "price": 9.00
+              },
+              {
+                "name": "Burger",
+                "price": 9.00
+              },
+              {
+                "name": "Chicken Wings",
+                "price": 9.00
+              }
+            ]
+          },
+          {
+            "name": "dinner",
+            "dishes": [
+              {
+                "name": "Mega \"Burger\"",
+                "price": 22.00
+              },
+              {
+                "name": "Lobster Mac & Cheese",
+                "price": 31.00
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }

--- a/spec/lib/tasks/import_rake_spec.rb
+++ b/spec/lib/tasks/import_rake_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+require "rake"
+
+RSpec.describe "import:restaurants", type: :task do
+  let(:task_name) { "import:restaurants" }
+  let(:task) do
+    Rake.application.rake_require('tasks/import')
+    Rake::Task.define_task(:environment)
+    Rake::Task[task_name]
+  end
+
+  let(:fixtures_file_path) { Rails.root.join("spec/fixtures/restaurants.json") }
+  let(:missing_file_path) { "tmp/missing.json" }
+  let(:exception_file_path) { "tmp/exception.json" }
+
+  before do
+    task.reenable
+    allow($stdout).to receive(:puts) # silence stdout to keep it clean
+  end
+
+  context "when no file path is provided" do
+    it "prints usage error and exits" do
+      expect { task.invoke }.to raise_error(SystemExit)
+      expect($stdout).to have_received(:puts).with(/Error: File path is required/)
+    end
+  end
+
+  context "when file does not exist" do
+    it "prints file not found error and exits" do
+      allow(File).to receive(:exist?).with(missing_file_path).and_return(false)
+
+      expect { task.invoke(missing_file_path) }.to raise_error(SystemExit)
+      expect($stdout).to have_received(:puts).with(/Error: File not found/)
+    end
+  end
+
+  context "when import is successful with all log levels" do
+    it "prints success message and logs" do
+      # Use the actual fixtures file
+      json_content = File.read(fixtures_file_path)
+
+      allow(File).to receive(:exist?).with(fixtures_file_path).and_return(true)
+      allow(File).to receive(:read).with(fixtures_file_path).and_return(json_content)
+
+      # Create example logs with all log levels to ensure full coverage
+      logs = [
+        { level: "info", message: "Created restaurant" },
+        { level: "warning", message: "No menus found" },
+        { level: "error", message: "Missing price" }
+      ]
+
+      service = instance_double(RestaurantImportService)
+      allow(RestaurantImportService).to receive(:new).and_return(service)
+      allow(service).to receive(:import).with(json_content).and_return({ success: true, logs: logs })
+
+      expect { task.invoke(fixtures_file_path) }.to raise_error(SystemExit)
+      expect($stdout).to have_received(:puts).with("Import successful")
+      expect($stdout).to have_received(:puts).with("  [INFO] Created restaurant")
+      expect($stdout).to have_received(:puts).with("  [WARNING] No menus found")
+      expect($stdout).to have_received(:puts).with("  [ERROR] Missing price")
+    end
+  end
+
+  context "when import fails" do
+    it "prints failure message and exits with code 1" do
+      json_content = File.read(fixtures_file_path)
+
+      allow(File).to receive(:exist?).with(fixtures_file_path).and_return(true)
+      allow(File).to receive(:read).with(fixtures_file_path).and_return(json_content)
+
+      service = instance_double(RestaurantImportService)
+      allow(RestaurantImportService).to receive(:new).and_return(service)
+      allow(service).to receive(:import).with(json_content).and_return({
+        success: false,
+        logs: [ { level: "error", message: "Bad data" } ]
+      })
+
+      expect { task.invoke(fixtures_file_path) }.to raise_error(SystemExit)
+      expect($stdout).to have_received(:puts).with("Import failed")
+      expect($stdout).to have_received(:puts).with("  [ERROR] Bad data")
+    end
+  end
+
+  context "when file reading raises an exception" do
+    it "prints the error and exits with code 1" do
+      allow(File).to receive(:exist?).with(exception_file_path).and_return(true)
+      allow(File).to receive(:read).with(exception_file_path).and_raise("Boom!")
+
+      expect { task.invoke(exception_file_path) }.to raise_error(SystemExit)
+      expect($stdout).to have_received(:puts).with(/Error: Boom!/)
+    end
+  end
+end

--- a/spec/services/restaurant_import_service_spec.rb
+++ b/spec/services/restaurant_import_service_spec.rb
@@ -1,0 +1,240 @@
+require 'rails_helper'
+
+RSpec.describe RestaurantImportService do
+  let(:service) { described_class.new }
+
+  describe '#import' do
+    context 'with valid JSON data' do
+      let(:valid_json) do
+        {
+          restaurants: [
+            {
+              name: "Test Restaurant",
+              menus: [
+                {
+                  name: "lunch",
+                  menu_items: [
+                    { name: "Burger", price: 9.0 },
+                    { name: "Salad", price: 5.0 }
+                  ]
+                }
+              ]
+            }
+          ]
+        }.to_json
+      end
+
+      it 'creates new restaurants, menus, and menu items' do
+        expect {
+          result = service.import(valid_json)
+          expect(result[:success]).to be true
+        }.to change(Restaurant, :count).by(1)
+          .and change(Menu, :count).by(1)
+          .and change(MenuItem, :count).by(2)
+          .and change(MenuEntry, :count).by(2)
+      end
+
+      it 'logs the creation of each entity' do
+        result = service.import(valid_json)
+
+        expect(result[:logs]).to include(
+          hash_including(level: 'info', message: including('Restaurant: Test Restaurant'))
+        )
+        expect(result[:logs]).to include(
+          hash_including(level: 'info', message: including('Menu: lunch'))
+        )
+        expect(result[:logs]).to include(
+          hash_including(level: 'info', message: including('Menu item: Burger'))
+        )
+      end
+
+      it 'handles duplicate menu items correctly' do
+        # Create the first restaurant with menu and items
+        service.import(valid_json)
+
+        # Create a second restaurant with the same menu item names
+        second_json = {
+          restaurants: [
+            {
+              name: "Another Restaurant",
+              menus: [
+                {
+                  name: "dinner",
+                  menu_items: [
+                    { name: "Burger", price: 12.0 }, # Same name, different price
+                    { name: "Pasta", price: 10.0 }   # New item
+                  ]
+                }
+              ]
+            }
+          ]
+        }.to_json
+
+        expect {
+          result = service.import(second_json)
+          expect(result[:success]).to be true
+        }.to change(Restaurant, :count).by(1)
+          .and change(Menu, :count).by(1)
+          .and change(MenuItem, :count).by(1) # Only Pasta is new, Burger already exists
+          .and change(MenuEntry, :count).by(2)
+
+        # Check that we have only one MenuItem with name "Burger"
+        expect(MenuItem.where(name: "Burger").count).to eq(1)
+
+        # Check that we have two MenuEntry records for "Burger" with different prices
+        burger = MenuItem.find_by(name: "Burger")
+        burger_entries = MenuEntry.where(menu_item_id: burger.id)
+        expect(burger_entries.count).to eq(2)
+
+        # Verify prices are correct
+        lunch_menu = Menu.find_by(name: "lunch")
+        dinner_menu = Menu.find_by(name: "dinner")
+
+        lunch_price = MenuEntry.find_by(menu_id: lunch_menu.id, menu_item_id: burger.id).price
+        dinner_price = MenuEntry.find_by(menu_id: dinner_menu.id, menu_item_id: burger.id).price
+
+        expect(lunch_price).to eq(9.0)
+        expect(dinner_price).to eq(12.0)
+      end
+    end
+
+    context 'with invalid JSON data' do
+      it 'handles invalid JSON format' do
+        result = service.import('{ invalid json }')
+
+        expect(result[:success]).to be false
+        expect(result[:logs].first[:level]).to eq('error')
+        expect(result[:logs].first[:message]).to include('JSON parsing error')
+      end
+
+      it 'handles missing restaurants array' do
+        result = service.import('{ "not_restaurants": [] }')
+
+        expect(result[:success]).to be false
+        expect(result[:logs].first[:level]).to eq('error')
+        expect(result[:logs].first[:message]).to include('Missing \'restaurants\' array')
+      end
+
+      it 'handles missing restaurant name' do
+        json = {
+          restaurants: [
+            {
+              # Missing name
+              menus: []
+            }
+          ]
+        }.to_json
+
+        result = service.import(json)
+
+        expect(result[:success]).to be false
+        expect(result[:logs]).to include(
+          hash_including(level: 'error', message: including('Missing or invalid \'name\''))
+        )
+      end
+
+      it 'handles missing menu name' do
+        json = {
+          restaurants: [
+            {
+              name: "Test Restaurant",
+              menus: [
+                {
+                  # Missing name
+                  menu_items: []
+                }
+              ]
+            }
+          ]
+        }.to_json
+
+        result = service.import(json)
+
+        expect(result[:success]).to be false
+        expect(result[:logs]).to include(
+          hash_including(level: 'error', message: including('Missing or invalid \'name\''))
+        )
+      end
+
+      it 'handles missing menu item data' do
+        json = {
+          restaurants: [
+            {
+              name: "Test Restaurant",
+              menus: [
+                {
+                  name: "lunch",
+                  menu_items: [
+                    { price: 9.0 } # Missing name
+                  ]
+                }
+              ]
+            }
+          ]
+        }.to_json
+
+        result = service.import(json)
+
+        expect(result[:success]).to be false
+        expect(result[:logs]).to include(
+          hash_including(level: 'error', message: including('Missing \'name\' or \'price\''))
+        )
+      end
+    end
+
+    context 'with alternate format for menu items' do
+      it 'handles "dishes" instead of "menu_items"' do
+        json = {
+          restaurants: [
+            {
+              name: "Test Restaurant",
+              menus: [
+                {
+                  name: "lunch",
+                  dishes: [ # Using dishes instead of menu_items
+                    { name: "Burger", price: 9.0 },
+                    { name: "Salad", price: 5.0 }
+                  ]
+                }
+              ]
+            }
+          ]
+        }.to_json
+
+        expect {
+          result = service.import(json)
+          expect(result[:success]).to be true
+        }.to change(MenuItem, :count).by(2)
+          .and change(MenuEntry, :count).by(2)
+      end
+    end
+
+    context 'with duplicate items in the same menu' do
+      it 'handles duplicate item names in the same menu' do
+        json = {
+          restaurants: [
+            {
+              name: "Test Restaurant",
+              menus: [
+                {
+                  name: "lunch",
+                  menu_items: [
+                    { name: "Chicken Wings", price: 9.0 },
+                    { name: "Burger", price: 9.0 },
+                    { name: "Chicken Wings", price: 9.0 } # Duplicate
+                  ]
+                }
+              ]
+            }
+          ]
+        }.to_json
+
+        expect {
+          result = service.import(json)
+          expect(result[:success]).to be true
+        }.to change(MenuItem, :count).by(2) # Only 2 unique items
+          .and change(MenuEntry, :count).by(2) # Only 2 unique menu entries
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a comprehensive RestaurantImportService designed to facilitate the bulk import of restaurant data from JSON payloads. The service efficiently processes nested structures encompassing restaurants, menus, and menu items, ensuring that existing records are appropriately updated and new entries are created as needed.

Key Enhancements:

Creation of the RestaurantImportService to handle JSON data ingestion.

Implementation of robust error handling and detailed logging mechanisms to track import operations.

Addition of RSpec tests to validate various import scenarios, including the creation of new records and updates to existing ones.

Integration of the service into the application's workflow to support seamless data importation.

These enhancements aim to streamline the process of importing complex restaurant data structures, improving the data management system's maintainability and scalability.